### PR TITLE
add pre-delete hook in order to remove capsule cr\crb

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -21,7 +21,7 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.1
+version: 0.0.2
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.

--- a/templates/pre-delete-job.yaml
+++ b/templates/pre-delete-job.yaml
@@ -1,0 +1,37 @@
+{{- $deploymentName := printf "%s-controller-manager" (include "capsule.fullname" .) -}}
+{{- $cmd := printf "kubectl scale deployment -n $NAMESPACE %s --replicas 0 && kubectl delete clusterroles.rbac.authorization.k8s.io capsule-namespace-deleter capsule-namespace-provisioner --ignore-not-found && kubectl delete clusterrolebindings.rbac.authorization.k8s.io capsule-namespace-provisioner --ignore-not-found" $deploymentName -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{ .Release.Name }}"
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+    app.kubernetes.io/instance: {{ .Release.Name | quote }}
+    app.kubernetes.io/version: {{ .Chart.AppVersion }}
+    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "{{ .Release.Name }}"
+      labels:
+        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+        app.kubernetes.io/instance: {{ .Release.Name | quote }}
+        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: pre-delete-job
+        image: "bitnami/kubectl:1.18"
+        command: ["sh", "-c",  {{ $cmd | quote }}]
+        env:
+          - name: NAMESPACE
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.namespace
+      serviceAccountName: {{ include "capsule.serviceAccountName" . }}


### PR DESCRIPTION
closes #12 

We need pre-delete hook, because if we use post-delete, service be deleted before job is created, so job will not have perms to delete capsule cr\crb

We need to scale capsule deployment to 0 pods, because if we don't do it and run job as pre-delete hook, capsule will recreate cr\crbs