### PR TITLE
Capsule v0.0.3 is out and minor improvement on FQDI

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -21,8 +21,8 @@ sources:
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.0.5
+version: 0.0.6
 
 # This is the version number of the application being deployed.
 # This version number should be incremented each time you make changes to the application.
-appVersion: 0.0.2
+appVersion: 0.0.3

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -61,3 +61,9 @@ Create the name of the service account to use
 {{- end }}
 {{- end }}
 
+{{/*
+Create the fully-qualified Docker image to use
+*/}}
+{{- define "capsule.fullyQualifiedDockerImage" -}}
+{{- printf "%s:%s" .Values.manager.image.repository ( .Values.manager.image.tag | default (printf "v%s" .Chart.AppVersion) ) -}}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,10 +49,10 @@ spec:
           - --metrics-addr=127.0.0.1:8080
           - --enable-leader-election
           - --zap-log-level={{ default 4 .Values.manager.options.logLevel }}
-          {{ if .Values.manager.options.forceTenantPrefix }}- --force-tenant-prefix={{ .Values.manager.options.forceTenantPrefix }}{{ end}}
+          {{ if .Values.manager.options.forceTenantPrefix }}- --force-tenant-prefix={{ .Values.manager.options.forceTenantPrefix }}{{ end }}
           {{ if .Values.manager.options.capsuleUserGroup }}- --capsule-user-group={{ .Values.manager.options.capsuleUserGroup }}{{ end }}
           {{ if .Values.manager.options.protectedNamespaceRegex }}- --protected-namespace-regex={{ .Values.manager.options.protectedNamespaceRegex }}{{ end }}
-          image: {{ .Values.manager.image.repository }}:{{ .Values.manager.image.tag | default .Chart.AppVersion }}
+          image: {{ include "capsule.fullyQualifiedDockerImage" . }}
           imagePullPolicy: {{ .Values.manager.image.pullPolicy }}
           env:
           - name: NAMESPACE


### PR DESCRIPTION
Bumping to [v0.0.3](https://github.com/clastix/capsule/releases/tag/v0.0.3).

Plus, minor improvement using Helm helpers for the final Docker image.